### PR TITLE
Add conda dependency "pip" to prevent warning loop

### DIFF
--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -13,6 +13,7 @@ dependencies:
 - graphviz
 - cython
 - testpath<0.4
+- pip
 - pip:
   - tensorflow
   - keras

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -13,6 +13,7 @@ dependencies:
 - graphviz
 - cython
 - testpath<0.4
+- pip
 - pip:
   - tensorflow-gpu
   - keras


### PR DESCRIPTION
안녕하세요. 기존에 만들어주신 environment-*.yml을 이용해 conda 환경을 구축하려고 하니 "Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip" 와 같은 경고 메시지가 무한히 출력되면서 환경이 만들어지지 않는 문제가 있었습니다. 해당 문제는 Ubuntu 20.04 및 Conda 4.10.1 환경을 가진 3개의 컴퓨터에서 모두 재현 가능했습니다.
해결 방법은 아래 예시와 같이 "- pip:" 바로 윗줄에 "- pip"를 추가함으로써 conda가 설치할 환경에 pip 자체도 추가하는 것이었으며, [[링크 1](https://stackoverflow.com/a/69010589)] 및 [[링크 2](https://github.com/conda/conda/blob/54e4a91d0da4d659a67e3097040764d3a2f6aa16/tests/conda_env/support/advanced-pip/environment.yml)] 를 참고하였습니다.

```yaml
...
- cython
- testpath<0.4
- pip
- pip:
  - tensorflow-gpu
  - keras
...
```